### PR TITLE
Replace `x509-certificate` with `x509-cert`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,12 +9,13 @@ license = "MIT"
 readme = "README.md"
 
 [dependencies]
+const-oid = { version = "0.9.6", features = ["db"] }
 ring = { version = "0.17", default-features = false }
 rustls = { version = "0.23", default-features = false }
 tokio = { version = "1", default-features = false }
 tokio-postgres = { version = "0.7", default-features = false }
 tokio-rustls = { version = "0.26", default-features = false }
-x509-certificate = {version = "0.23", default-features = false }
+x509-cert = { version = "0.2.5", default-features = false, features = ["std"] }
 
 [dev-dependencies]
 env_logger = { version = "0.11", default-features = false }


### PR DESCRIPTION
## Feature or Problem

Apply https://github.com/jbg/tokio-postgres-rustls/pull/24 to our fork

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
